### PR TITLE
ISSUE-525 / 764: ruby-kafka does not support different topic subscriptions in the same consumer group

### DIFF
--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -190,9 +190,14 @@ module Kafka
       if group_leader?
         @logger.info "Chosen as leader of group `#{@group_id}`"
 
+        topics = Set.new
+        @members.each do |_member, metadata|
+          metadata.topics.each { |t| topics.add(t) }
+        end
+
         group_assignment = @assignor.assign(
           members: @members,
-          topics: @topics,
+          topics: topics,
         )
       end
 

--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -3,6 +3,7 @@
 require "set"
 require "kafka/consumer_group/assignor"
 require "kafka/round_robin_assignment_strategy"
+require "kafka/multi_subscription_round_robin_assignment_strategy"
 
 module Kafka
   class ConsumerGroup

--- a/lib/kafka/multi_subscription_round_robin_assignment_strategy.rb
+++ b/lib/kafka/multi_subscription_round_robin_assignment_strategy.rb
@@ -1,0 +1,53 @@
+module Kafka
+
+  # A round robin assignment strategy suitable for when subscriptions
+  # differ across consumer instances in the same consumer group.
+  class MultiSubscriptionRoundRobinAssignmentStrategy
+    def protocol_name
+      "roundrobin"
+    end
+
+    # Assign the topic partitions to the group members.
+    #
+    # @param cluster [Kafka::Cluster]
+    # @param members [Hash<String, Kafka::Protocol::JoinGroupResponse::Metadata>] a hash
+    #   mapping member ids to metadata
+    # @param partitions [Array<Kafka::ConsumerGroup::Assignor::Partition>] a list of
+    #   partitions the consumer group processes
+    # @return [Hash<String, Array<Kafka::ConsumerGroup::Assignor::Partition>] a hash
+    #   mapping member ids to partitions.
+    def call(cluster:, members:, partitions:)
+      partitions_per_member = Hash.new {|h, k| h[k] = [] }
+      relevant_partitions = valid_sorted_partitions(members, partitions)
+      members_ids = members.keys
+      idx = 0
+
+      relevant_partitions.each do |partition|
+        topic = partition.topic
+
+        while !members[members_ids[idx]].topics.include?(topic)
+          idx = next_index(members_ids, idx)
+        end
+
+        partitions_per_member[members_ids[idx]] << partition
+        idx = next_index(members_ids, idx)
+      end
+
+      partitions_per_member
+    end
+
+    def valid_sorted_partitions(members, partitions)
+      subscribed_topics = members.map { |id, metadata| metadata&.topics }.flatten.compact
+      partitions
+        .select { |partition| subscribed_topics.include?(partition.topic) }
+        .sort_by { |partition| partition.topic }
+    end
+
+    def next_index(members_ids, idx)
+      idx += 1
+      idx = 0 if idx == members_ids.size
+
+      idx
+    end
+  end
+end

--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -518,6 +518,68 @@ describe "Consumer API", functional: true do
     expect(received_messages.values.map(&:count)).to match_array [messages.count / 3, messages.count / 3 * 2]
   end
 
+  example "subscribing to different topics while in the same consumer group" do
+    topic1 = create_random_topic(num_partitions: 1)
+    topic2 = create_random_topic(num_partitions: 1)
+    messages = (1..500).to_a
+
+    begin
+      kafka = Kafka.new(kafka_brokers, client_id: "test")
+      producer = kafka.producer
+
+      messages[0..249].each do |i|
+        producer.produce(i.to_s, topic: topic1, partition: 0)
+      end
+
+      messages[250..500].each do |i|
+        producer.produce(i.to_s, topic: topic2, partition: 0)
+      end
+
+      producer.deliver_messages
+    end
+
+    group_id = "test#{rand(1000)}"
+
+    mutex = Mutex.new
+    received_messages = []
+
+    assignment_strategy_class = Kafka::MultiSubscriptionRoundRobinAssignmentStrategy
+
+    consumers = [topic1, topic2].map do |topic|
+      assignment_strategy = assignment_strategy_class.new
+      kafka = Kafka.new(kafka_brokers, client_id: "test", logger: logger)
+      consumer = kafka.consumer(
+        group_id: group_id,
+        offset_retention_time: offset_retention_time,
+        assignment_strategy: assignment_strategy
+      )
+      consumer.subscribe(topic)
+      consumer
+    end
+
+    threads = consumers.map do |consumer|
+      t = Thread.new do
+        consumer.each_message do |message|
+          mutex.synchronize do
+            received_messages << message
+
+            if received_messages.count == messages.count
+              consumers.each(&:stop)
+            end
+          end
+        end
+      end
+
+      t.abort_on_exception = true
+
+      t
+    end
+
+    threads.each(&:join)
+
+    expect(received_messages.map(&:value).map(&:to_i)).to match_array messages
+  end
+
   def wait_until(timeout:)
     Timeout.timeout(timeout) do
       sleep 0.5 until yield

--- a/spec/multi_subscription_round_robin_assignment_strategy_spec.rb
+++ b/spec/multi_subscription_round_robin_assignment_strategy_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+describe Kafka::MultiSubscriptionRoundRobinAssignmentStrategy do
+  let(:strategy) { described_class.new }
+
+  # We need to ensure that the new strategy is backwards compatible
+  # with the previous one. The following tests were backported from the
+  # RoundRobinAssignmentStrategy specs.
+  context 'RoundRobinAssignmentStrategy specs' do
+    it "assigns all partitions" do
+      members = Hash[(0...10).map {|i| ["member#{i}", double(topics: ['greetings'])] }]
+      partitions = (0...30).map {|i| double(:"partition#{i}", topic: "greetings", partition_id: i) }
+
+      assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
+
+      partitions.each do |partition|
+        member = assignments.values.find {|assigned_partitions|
+          assigned_partitions.find {|assigned_partition|
+            assigned_partition == partition
+          }
+        }
+
+        expect(member).to_not be_nil
+      end
+    end
+
+    it "spreads all partitions between members" do
+      topics = ["topic1", "topic2"]
+      members = Hash[(0...10).map {|i| ["member#{i}", double(topics: topics)] }]
+      partitions = topics.product((0...5).to_a).map {|topic, i|
+        double(:"partition#{i}", topic: topic, partition_id: i)
+      }
+
+      assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
+
+      partitions.each do |partition|
+        member = assignments.values.find {|assigned_partitions|
+          assigned_partitions.find {|assigned_partition|
+            assigned_partition == partition
+          }
+        }
+
+        expect(member).to_not be_nil
+      end
+
+      num_partitions_assigned = assignments.values.map do |assigned_partitions|
+        assigned_partitions.count
+      end
+
+      expect(num_partitions_assigned).to all eq(1)
+    end
+
+    Metadata = Struct.new(:topics)
+    [
+      {
+        name: "uneven topics",
+        topics: { "topic1" => [0], "topic2" => (0..50).to_a },
+        members: {
+          "member1" => Metadata.new(["topic1", "topic2"]),
+          "member2" => Metadata.new(["topic1", "topic2"])
+        },
+      },
+      {
+        name: "only one partition",
+        topics: { "topic1" => [0] },
+        members: {
+          "member1" => Metadata.new(["topic1"]),
+          "member2" => Metadata.new(["topic1"])
+        },
+      },
+      {
+        name: "lots of partitions",
+        topics: { "topic1" => (0..100).to_a },
+        members: { "member1" => Metadata.new(["topic1"]) },
+      },
+      {
+        name: "lots of members",
+        topics: { "topic1" => (0..10).to_a, "topic2" => (0..10).to_a },
+        members: Hash[(0..50).map { |i| ["member#{i}", Metadata.new(["topic1", "topic2"])] }]
+      },
+      {
+        name: "odd number of partitions",
+        topics: { "topic1" => (0..14).to_a },
+        members: {
+          "member1" => Metadata.new(["topic1"]),
+          "member2" => Metadata.new(["topic1"])
+        },
+      },
+      {
+        name: "five topics, 10 partitions, 3 consumers",
+        topics: { "topic1" => [0, 1], "topic2" => [0, 1], "topic3" => [0, 1], "topic4" => [0, 1], "topic5" => [0, 1] },
+        members: {
+          "member1" => Metadata.new(["topic1", "topic2", "topic3", "topic4", "topic5"]),
+          "member2" => Metadata.new(["topic1", "topic2", "topic3", "topic4", "topic5"]),
+          "member3" => Metadata.new(["topic1", "topic2", "topic3", "topic4", "topic5"])
+        },
+      }
+    ].each do |options|
+      name, topics, members = options[:name], options[:topics], options[:members]
+      it name do
+        partitions = topics.flat_map {|topic, partition_ids|
+          partition_ids.map {|i|
+            double(:"partition#{i}", topic: topic, partition_id: i)
+          }
+        }
+
+        assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
+
+        expect_all_partitions_assigned(topics, assignments)
+        expect_even_assignments(topics, assignments)
+      end
+    end
+
+    def expect_all_partitions_assigned(topics, assignments)
+      topics.each do |topic, partition_ids|
+        partition_ids.each do |partition_id|
+          assigned = assignments.values.find do |assigned_partitions|
+            assigned_partitions.find {|assigned_partition|
+              assigned_partition.topic == topic && assigned_partition.partition_id == partition_id
+            }
+          end
+          expect(assigned).to_not be_nil
+        end
+      end
+    end
+
+    def expect_even_assignments(topics, assignments)
+      num_partitions = topics.values.flatten.count
+      assignments.values.each do |assigned_partition|
+        num_assigned = assigned_partition.count
+        expect(num_assigned).to be_within(1).of(num_partitions.to_f / assignments.count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are 2 issues that currently prevent supporting this feature:

1. **The current `RoundRobinAssignmentStrategy` assumes all subscriptions are equal**

We need a more generalized algorithm to perform assignments now that we have different subscriptions across the consumer group. This PR introduces a new additional strategy heavily inspired in the java kafka client [RoundRobinAssignor](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/RoundRobinAssignor.java) that properly handle this case.

2. **The leader consumer thread assumes that all consumers subscription are equivalent**

If different consumers were to have different topic subscription we can't rely on the in-memory `@topics` variable to produce correct assignments. Instead, we can leverage the subscription information provided by the cluster, and stored in`@members`, to determine the correct consumer subscriptions for a particular consumer group. Once we have the correct list of topics the downstream code in the assignor can then fetch the corresponding partitions from the cluster in preparation for the assignments.